### PR TITLE
Remove "FollowSymLinks"

### DIFF
--- a/watermark.php
+++ b/watermark.php
@@ -233,7 +233,6 @@ class Watermark extends Module
         $admin_dir = $this->getAdminDir();
         $source = "\n# start ~ module watermark section
 <IfModule mod_rewrite.c>
-Options +FollowSymLinks
 RewriteEngine On
 RewriteCond expr \"! %{HTTP_REFERER} -strmatch '*://%{HTTP_HOST}*/$admin_dir/*'\"
 RewriteRule [0-9/]+/[0-9]+\\.jpg$ - [F]


### PR DESCRIPTION
"+FollowSymLinks" can cause security issues, because with such a symlink into a foreign users' home directory, the webserver would be able to read files the user must not have access to. Instead, hosting providers require "SymlinksIfOwnerMatch":

https://www.drupal.org/node/2625224

Removing the line from watermark.php is probably preferred here: Prestashop itself should handle the proper mod_rewrite configuration syntax, so a single module can assume that everything is already working.