### PR TITLE
MO: Prepending module rewrite rules to .htaccess instead of appending

### DIFF
--- a/watermark.php
+++ b/watermark.php
@@ -241,7 +241,7 @@ RewriteRule [0-9/]+/[0-9]+\\.jpg$ - [F]
 # end ~ module watermark section\n";
 
         $path = _PS_ROOT_DIR_.'/.htaccess';
-        file_put_contents($path, $source, FILE_APPEND);
+        file_put_contents($path, $source . file_get_contents($path));
     }
 
     public function getContent()


### PR DESCRIPTION
Thank you for the module.

When I directly visit the original image via browser adress bar (no http referrer), they unfortunately appear, which is not the aim of the module IMHO.

examples that work:

ip_address/4/6/46.jpg
ip_address/img/p/4/6/46.jpg


I noticed that moving the module rules to the top of the .htaccess makes the urls lead to 403 forbidden as intended.

Thank you.

