### PR TITLE
Fix error 500 due to "Options +FollowSymLinks" in htaccess

### DIFF
--- a/watermark.php
+++ b/watermark.php
@@ -295,7 +295,7 @@ class Watermark extends Module
         $adminDir = $this->getAdminDir();
         $source = "\n# start ~ module watermark section
 <IfModule mod_rewrite.c>
-Options +FollowSymLinks
+Options +SymLinksIfOwnerMatch
 RewriteEngine On
 RewriteCond expr \"! %{HTTP_REFERER} -strmatch '*://%{HTTP_HOST}*/$adminDir/*'\"
 RewriteRule [0-9/]+/[0-9]+\\.jpg$ - [F]


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | For security reason many providers uses SymLinksIfOwnerMatch instead to FollowSymLinks
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | unknown
| How to test?  | use +FollowSymLinks in some hosting give error 500 because soem host block the use of FollowSymLinks


